### PR TITLE
[hotfix] Remove unnecessary call to ClearInputCharacters in keyboard handler

### DIFF
--- a/src/raytracing/gui/App.cpp
+++ b/src/raytracing/gui/App.cpp
@@ -155,7 +155,6 @@ namespace Raytracing
         // call the keyboard handler
         keyboardHandler();
         io.ClearInputKeys();
-        io.ClearInputCharacters();
 
         // if there is a image : draw it
         if (const GLuint imageTextureId = renderer.getTextureId())


### PR DESCRIPTION
as it is deprecated in recent versions of imgui